### PR TITLE
use destructuring instead of temporary variable

### DIFF
--- a/js/agent.js
+++ b/js/agent.js
@@ -130,9 +130,7 @@ class Agent {
 	}
 
 	flocking() {
-		const arrays = this.getNearAgents();
-		const agents = arrays[0];
-		const distancesSq = arrays[1];
+		const [ agents, distancesSq ] = this.getNearAgents();
 
 		this.acceleration.x = this.acceleration.y = 0;
 


### PR DESCRIPTION
the code is more concise and you use less memory for the temporary variable reference
i don't think it'll increase performance but it bothered me lmao